### PR TITLE
Fix JSON Input Parser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/JsonInjectionParser.java
+++ b/src/main/java/seedu/address/logic/parser/JsonInjectionParser.java
@@ -9,7 +9,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class JsonInjectionParser {
     // List of possible JSON commands.
-    private final String quote = "\'";
     private final String hexEscape = "\\x";
     private final String octalEscape = "\\0";
     private final String comma = ",";
@@ -18,7 +17,7 @@ public class JsonInjectionParser {
     private final String openCurlyBrackets = "{";
     private final String closedCurlyBrackets = "}";
     private String[] wordsToSanitise =
-            new String[]{quote, hexEscape, octalEscape, comma, openParentheses, closedParentheses,
+            new String[]{hexEscape, octalEscape, comma, openParentheses, closedParentheses,
                 openCurlyBrackets, closedCurlyBrackets};
 
     /**

--- a/src/test/java/seedu/address/logic/parser/JsonInjectionParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/JsonInjectionParserTest.java
@@ -11,17 +11,6 @@ public class JsonInjectionParserTest {
     private static final JsonInjectionParser parser = new JsonInjectionParser();
 
     @Test
-    public void parse_singleInvalidInput_throwsException() {
-        String testString = "This is a te'st input";
-        Exception exception = assertThrows(ParseException.class, () -> {
-            parser.parse(testString);
-        });
-        String expectedMessage = "Please do not input JSON like content";
-        String actualMessage = exception.getMessage();
-        assertTrue(actualMessage.contains(expectedMessage));
-    }
-
-    @Test
     public void parse_multipleInvalidInputs_throwsException() {
         String testString = "This \\x0 is a te'st inp:ut()";
         Exception exception = assertThrows(ParseException.class, () -> {


### PR DESCRIPTION
The quote sanitation makes it so that the remarks field cannot contain possessive / plural forms of certain words.

As such it has been removed.