### PR TITLE
Fix Launch GUI size

### DIFF
--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -4,6 +4,7 @@ import java.awt.Point;
 import java.io.Serializable;
 import java.util.Objects;
 
+import javafx.stage.Screen;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
@@ -12,8 +13,8 @@ import seedu.address.commons.util.ToStringBuilder;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_HEIGHT = Screen.getPrimary().getVisualBounds().getHeight();
+    private static final double DEFAULT_WIDTH = Screen.getPrimary().getVisualBounds().getWidth();
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -4,6 +4,7 @@ import java.awt.Point;
 import java.io.Serializable;
 import java.util.Objects;
 
+import javafx.geometry.Rectangle2D;
 import javafx.stage.Screen;
 import seedu.address.commons.util.ToStringBuilder;
 
@@ -13,8 +14,8 @@ import seedu.address.commons.util.ToStringBuilder;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = Screen.getPrimary().getVisualBounds().getHeight();
-    private static final double DEFAULT_WIDTH = Screen.getPrimary().getVisualBounds().getWidth();
+    private static final double DEFAULT_HEIGHT = 500;
+    private static final double DEFAULT_WIDTH = 500;
 
     private final double windowWidth;
     private final double windowHeight;
@@ -24,8 +25,9 @@ public class GuiSettings implements Serializable {
      * Constructs a {@code GuiSettings} with the default height, width and position.
      */
     public GuiSettings() {
-        windowWidth = DEFAULT_WIDTH;
-        windowHeight = DEFAULT_HEIGHT;
+        Rectangle2D screenBounds = Screen.getPrimary().getVisualBounds();
+        windowWidth = screenBounds.getWidth() * 0.8;
+        windowHeight = screenBounds.getHeight() * 0.8;
         windowCoordinates = null; // null represent no coordinates
     }
 

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -14,8 +14,8 @@ import seedu.address.commons.util.ToStringBuilder;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = 500;
-    private static final double DEFAULT_WIDTH = 500;
+    private static final double DEFAULT_HEIGHT = 600;
+    private static final double DEFAULT_WIDTH = 740;
 
     private final double windowWidth;
     private final double windowHeight;
@@ -25,9 +25,8 @@ public class GuiSettings implements Serializable {
      * Constructs a {@code GuiSettings} with the default height, width and position.
      */
     public GuiSettings() {
-        Rectangle2D screenBounds = Screen.getPrimary().getVisualBounds();
-        windowWidth = screenBounds.getWidth() * 0.8;
-        windowHeight = screenBounds.getHeight() * 0.8;
+        windowWidth = DEFAULT_WIDTH;
+        windowHeight = DEFAULT_HEIGHT;
         windowCoordinates = null; // null represent no coordinates
     }
 
@@ -38,6 +37,15 @@ public class GuiSettings implements Serializable {
         this.windowWidth = windowWidth;
         this.windowHeight = windowHeight;
         windowCoordinates = new Point(xPosition, yPosition);
+    }
+
+    /**
+     * Initializes GuiSettings with the size of the screen. To be used when JavaFX is initialized.
+     */
+    public static GuiSettings fromScreenDimensions() {
+        Rectangle2D screenBounds = Screen.getPrimary().getVisualBounds();
+        return new GuiSettings(screenBounds.getWidth(), screenBounds.getHeight(),
+                0, 0);
     }
 
     public double getWindowWidth() {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -37,7 +37,6 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private RoomPieChart roomPieChart;
-
     @FXML
     private StackPane commandBoxPlaceholder;
 
@@ -135,6 +134,7 @@ public class MainWindow extends UiPart<Stage> {
      * Sets the default size based on {@code guiSettings}.
      */
     private void setWindowDefaultSize(GuiSettings guiSettings) {
+        guiSettings = GuiSettings.fromScreenDimensions();
         primaryStage.setHeight(guiSettings.getWindowHeight());
         primaryStage.setWidth(guiSettings.getWindowWidth());
         if (guiSettings.getWindowCoordinates() != null) {


### PR DESCRIPTION
Modified default parameters to be the size of the display instead; as such all components will be visible on App Launch without the need for user adjustment.

Close #206 
Close #216 